### PR TITLE
Fix sidebar navigation arrow orientation when collapsed

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -138,4 +138,12 @@
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }
+
+  & img {
+    transition: transform 300ms ease-in-out;
+  }
+
+  &.isCollapsed img {
+    transform: rotate(180deg);
+  }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.isCollapsed,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
Previously, the sidebar navigation arrow always pointed left, regardless of the navigation state, which was inconsistent with the UI behavior. This PR corrects the arrow's orientation by rotating it to the right when the sidebar is collapsed, ensuring consistent and intuitive navigation for users.