### PR TITLE
Fix behavior of sidebar navigation support button

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -31,6 +31,19 @@ describe("Sidebar Navigation", () => {
         .should("have.attr", "href", "/dashboard/settings");
     });
 
+    it("opens mail client with correct parameters on support icon click", () => {
+      cy.window().then((window) => {
+        cy.stub(window, "open").as("windowOpen");
+      });
+
+      cy.get("img[alt='Support icon']").click();
+
+      cy.get("@windowOpen").should(
+        "have.been.calledWith",
+        "mailto:support@prolog-app.com?subject=Support%20Request%3A",
+      );
+    });
+
     it("is collapsible", () => {
       // collapse navigation
       cy.get("nav").contains("Collapse").click();

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -20,6 +20,15 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const openMailClient = () => {
+    const recipient = "support@prolog-app.com";
+    const subject_line = encodeURIComponent("Support Request:");
+    const mailClientLink = `mailto:${recipient}?subject=${subject_line}`;
+
+    window.open(mailClientLink);
+  };
+
   return (
     <div
       className={classNames(
@@ -83,7 +92,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() => openMailClient()}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
Previously, the sidebar navigation's support button triggered a simple alert when clicked. This pull request enhances its functionality by enabling it to open the user's default mail client with pre-filled information, including the recipient email address and subject line.

Additionally, an end-to-end Cypress test has been created to cover the expected behavior of the button's new functionality.