### PR TITLE
Fix navigation logo when switching to mobile

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,0 +1,1 @@
+export const DESKTOP_MEDIA_QUERY = "(min-width: 64em)";

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -7,6 +7,8 @@ import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
 import styles from "./sidebar-navigation.module.scss";
+import useMediaQuery from "hooks/useMediaQuery";
+import { DESKTOP_MEDIA_QUERY } from "@config/constants";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
@@ -20,6 +22,7 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const isDesktopView = useMediaQuery(DESKTOP_MEDIA_QUERY);
 
   const openMailClient = () => {
     const recipient = "support@prolog-app.com";
@@ -46,7 +49,7 @@ export function SidebarNavigation() {
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={
-              isSidebarCollapsed
+              isSidebarCollapsed && isDesktopView
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+const useMediaQuery = (mediaQuery: string) => {
+  const [mediaMatched, setMediaMatched] = useState(false);
+
+  useEffect(() => {
+    const mediaQueryList = window.matchMedia(mediaQuery);
+
+    setMediaMatched(mediaQueryList.matches);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMediaMatched(event.matches);
+    };
+
+    mediaQueryList.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", handleChange);
+    };
+  }, [mediaQuery]);
+
+  return mediaMatched;
+};
+
+export default useMediaQuery;


### PR DESCRIPTION
This pull request addresses an issue where the wrong logo was displayed on mobile devices after the user switched orientation. To fix this, a custom React hook has been implemented to detect the viewport size. This information is then used by the sidebar navigation component to conditionally render the correct logo based on both the viewport size and the collapse state of the sidebar. This ensures that the appropriate logo is always displayed on mobile devices, regardless of orientation or sidebar state.